### PR TITLE
Set the default hapi version to 2.x

### DIFF
--- a/hapi/data.js
+++ b/hapi/data.js
@@ -71,7 +71,7 @@ var generatorData = {
 			quickInstall: false
 		},
 		hapiDependencies: {
-			hapiVersion: 'latest',
+			hapiVersion: '~2.x',
 			hapiDepend: [
 				'catbox',
 				'joi'


### PR DESCRIPTION
The latest version of Hapi is the number 3. This new version is not compatible with the initial `server.js` code of the generator. So for the moment I just put the default version to 2, until we adapt the code for the latest version.
