### PR TITLE
Remove 'travelogue' dependency

### DIFF
--- a/hapi/data.js
+++ b/hapi/data.js
@@ -3,6 +3,10 @@
 var generatorData = {
 
 	hapiDependencies: {
+		'bell' : {
+			moduleName: 'bell',
+			description: 'Third-party login plugin for hapi'
+		},
 		'catbox' : {
 			moduleName: 'catbox',
 			description: 'Multi-strategy object caching service'
@@ -12,6 +16,10 @@ var generatorData = {
 			description: 'A systematic toolchain for benchmarking and comparing Node.js web server ' +
 			'frameworks'
 		},
+		'hapi-auth-cookie' : {
+			moduleName: 'hapi-auth-cookie',
+			description: 'Cookie authentication plugin'
+		},
 		'joi' : {
 			moduleName: 'joi',
 			description: 'Object schema description language and validator for JavaScript objects'
@@ -20,10 +28,6 @@ var generatorData = {
 			moduleName: 'shot',
 			description: 'Injects a fake HTTP request/response into a node HTTP server for simulating ' +
 			'server logic'
-		},
-		'travelogue' : {
-			moduleName: 'travelogue',
-			description: 'Passport.js integration for hapi'
 		},
 		'yar' : {
 			moduleName: 'yar',


### PR DESCRIPTION
`travelogue` dependency make the `npm install` crash, because of the hapi version required.
But travelogue is not maintained anymore (https://github.com/hapijs/travelogue), the team recommend to use `bell` and/or `hapi-auth-cookie`.
So I've updated `hapi/data.js`.
The hapi install works fine now.
